### PR TITLE
Fixed large empty space under flash messages

### DIFF
--- a/app/assets/stylesheets/app/_flash-messages.scss
+++ b/app/assets/stylesheets/app/_flash-messages.scss
@@ -1,6 +1,6 @@
 .flash-message {
   padding-top: 7.5rem;
-  margin-bottom: 0;
+  margin-bottom: -6.5rem;
   @extend %thredded--alert;
 }
 


### PR DESCRIPTION
flash messages no longer push the rest of the page down
done via negative bottom margin in flash message CSS